### PR TITLE
chore: add env var lookup for RapportNav API key

### DIFF
--- a/.gitlab-ci/roles/install_docker_image/vars/main.yml
+++ b/.gitlab-ci/roles/install_docker_image/vars/main.yml
@@ -49,4 +49,6 @@ data_warehouse_pwd: "{{ lookup('env', 'DATA_WAREHOUSE_PWD') }}"
 api_key_datagouv: "{{ lookup('env', 'DATAGOUV_API_KEY') }}"
 rapportnav_api_key: "{{ lookup('env', 'RAPPORTNAV_API_KEY') }}"
 
+###########################API_URL###########################
+rapportnav_api_url: "{{ lookup('env', 'RAPPORTNAV_API_URL') }}"
 prefect_server_url: "{{ lookup('env', 'PREFECT_SERVER_URL') }}"

--- a/.gitlab-ci/templates/.env.j2
+++ b/.gitlab-ci/templates/.env.j2
@@ -51,5 +51,5 @@ DATAGOUV_API_KEY={{ api_key_datagouv }}
 
 # API RapportNav
 RAPPORTNAV_API_KEY={{ rapportnav_api_key }}
-
+RAPPORTNAV_API_URL={{ rapportnav_api_url }}
 


### PR DESCRIPTION
Ajout du mapping pour la var d'env pour la clé API RapportNav

ATTENTION : il faudra bien pull ce commit sur le gitlab correspondant: https://gitlab-sml.din.developpement-durable.gouv.fr/applications/peche/datawarehouse/-/commit/aeba3a9318f2a6cb2c6c5fd99167f645737981f0
