### PR TITLE
fix(RapportNav): Parser le champ start_datetime_utc dans la query

### DIFF
--- a/forklift/forklift/pipeline/flows/extract_rapportnav_analytics.py
+++ b/forklift/forklift/pipeline/flows/extract_rapportnav_analytics.py
@@ -79,6 +79,7 @@ def extract_missions_ids() -> list:
     mission_ids = extract(
         db_name="monitorenv_remote",
         query_filepath="monitorenv_remote/missions.sql",
+        parse_dates=['start_datetime_utc']
     )
 
     logger.info(


### PR DESCRIPTION
Le filtre `where start_datetime_utc >= '2025-01-01'`  dans `missions.sql`ne fonctionne pas en production.

Une seule mission est renvoyée. 

Depuis metabase, avec la même requête sur la même base, plusieurs centaines de missions sont renvoyées.