### PR TITLE
fix(RapportNav): Laisser pandas gérer les erreurs de parsing de dates

### DIFF
--- a/forklift/forklift/pipeline/flows/extract_rapportnav_analytics.py
+++ b/forklift/forklift/pipeline/flows/extract_rapportnav_analytics.py
@@ -95,8 +95,8 @@ def _process_data(df: pd.DataFrame, report_type: str) -> pd.DataFrame:
         df.columns.str.replace(".", "_").str.replace(" ", "_").str.replace("'", "_")
     )
     if not df.empty:
-        df["startDateTimeUtc"] = pd.to_datetime(df["startDateTimeUtc"])
-        df["endDateTimeUtc"] = pd.to_datetime(df["endDateTimeUtc"])
+        df["startDateTimeUtc"] = pd.to_datetime(df["startDateTimeUtc"], errors="coerce")
+        df["endDateTimeUtc"] = pd.to_datetime(df["endDateTimeUtc"], errors="coerce")
 
         # Deal with potential null values
         df["facade"] = df["facade"].fillna("NON_RESEIGNE")


### PR DESCRIPTION
Pour réparer l'erreur en production :
`Error during execution of task: ValueError('time data "2025-01-16T10:11:42.303Z" doesn\'t match format "%Y-%m-%dT%H:%M:%S%z", at position 9. You might want to try:\n - passing format if your strings have a consistent format;\n - passing format=\'ISO8601\' if your strings are all ISO8601 but not necessarily in exactly the same format;\n - passing format=\'mixed\', and the format will be inferred for each element individually. You might want to use dayfirst alongside this.')`