### PR TITLE
Ajout données liées aux avaries VMS

### DIFF
--- a/forklift/forklift/pipeline/flow_schedules/sync_table_from_db_connection.csv
+++ b/forklift/forklift/pipeline/flow_schedules/sync_table_from_db_connection.csv
@@ -21,3 +21,6 @@
 "monitorfish_proxy","beacon_malfunctions",,"monitorfish","beacon_malfunctions",,"id","8 5 * * *"
 "monitorenv_proxy","natinfs",,"monitorenv","natinfs",,"natinf_code","10 5 * * *"
 "rapportnav_proxy",,"data_warehouse/missions_aem.sql","rapportnav","missions_aem",,"mission_date_debut","12 5 * * *"
+"monitorfish_proxy","beacon_malfunction_actions",,"monitorfish","beacon_malfunction_actions",,"id","14 5 * * *"
+"monitorfish_proxy","beacon_malfunction_comments",,"monitorfish","beacon_malfunction_comments",,"id","16 5 * * *"
+"monitorfish_proxy","beacon_malfunction_notifications",,"monitorfish","beacon_malfunction_notifications",,"id","18 5 * * *"

--- a/forklift/tests/test_data/monitorenv/remote_database/V777.04__dummy_env_actions_aem_test.sql
+++ b/forklift/tests/test_data/monitorenv/remote_database/V777.04__dummy_env_actions_aem_test.sql
@@ -1,8 +1,8 @@
 -- =====================================================================
 -- Fixture de test AEM — env_actions + themes_env_actions pour la mission
--- fictive 999001, couvrant 3.3 (espèces protégées, thème 103), 4.1
--- (surveillance hors rejets illicites), 4.2 (pollution, thème 19/102),
--- 4.4 (biens culturels, thème 104/165). Structure JSON de `value`
+-- fictive 999001, couvrant 3.3 (espèces protégées, thème 999103), 4.1
+-- (surveillance hors rejets illicites), 4.2 (pollution, thème 99919/102),
+-- 4.4 (biens culturels, thème 999104/999165). Structure JSON de `value`
 -- reprise de celle exploitée par missions_aem.sql (vehicleType,
 -- actionNumberOfControls, infractions[{natinf, infractionType}]).
 --
@@ -10,7 +10,7 @@
 -- cette table est peuplée dynamiquement à partir de control_plan_themes/
 -- control_plan_sub_themes (données de plan de contrôle, réimportées
 -- chaque année, cf. V666.0__Reset_themes_and_tags.sql côté monitorenv).
--- Les ids 103/19/102/104/165 utilisés dans missions_aem.sql ne sont
+-- Les ids 999103/99919/102/999104/999165 utilisés dans missions_aem.sql ne sont
 -- donc PAS garantis stables entre environnements ni dans le temps --
 -- à signaler à l'équipe : la requête de production devrait idéalement
 -- résoudre ces thèmes par nom plutôt que par id en dur.
@@ -21,11 +21,11 @@
 -- =====================================================================
 
 INSERT INTO public.themes (id, name, started_at, ended_at) VALUES
-    (103, 'Test AEM - Espèces protégées', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
-    (19,  'Test AEM - Pollution 19', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
-    (102, 'Test AEM - Pollution 102', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
-    (104, 'Test AEM - Biens culturels', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
-    (165, 'Test AEM - Biens culturels (opérations scientifiques)', '2023-01-01 00:00:00', '2099-12-31 23:59:59')
+    (999103, 'Test AEM - Espèces protégées', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
+    (99919,  'Test AEM - Pollution 99919', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
+    (999102, 'Test AEM - Pollution 102', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
+    (999104, 'Test AEM - Biens culturels', '2023-01-01 00:00:00', '2099-12-31 23:59:59'),
+    (999165, 'Test AEM - Biens culturels (opérations scientifiques)', '2023-01-01 00:00:00', '2099-12-31 23:59:59')
 ;
 SELECT setval('themes_id_seq', (SELECT MAX(id) FROM public.themes));
 
@@ -33,27 +33,27 @@ INSERT INTO public.env_actions (
     id, mission_id, action_type, action_start_datetime_utc,
     action_end_datetime_utc, value
 ) VALUES
-    -- 3.3 : trafic espèces protégées (thème 103)
+    -- 3.3 : trafic espèces protégées (thème 999103)
     ('99999905-0000-0000-0000-000000000001', 999001, 'CONTROL',
      '2025-06-10 20:00:00+00', '2025-06-10 22:00:00+00',
      '{"vehicleType": "VESSEL", "actionNumberOfControls": 1, "infractions": []}'),
 
-    -- 4.1 : surveillance hors rejets illicites (sans thème 19/102)
+    -- 4.1 : surveillance hors rejets illicites (sans thème 99919/102)
     ('99999905-0000-0000-0000-000000000002', 999001, 'SURVEILLANCE',
      '2025-06-11 06:00:00+00', '2025-06-11 07:00:00+00',
      '{"vehicleType": "VESSEL"}'),
 
-    -- 4.2 côté env : pollution (thème 19), avec infraction + PV
+    -- 4.2 côté env : pollution (thème 99919), avec infraction + PV
     ('99999905-0000-0000-0000-000000000003', 999001, 'CONTROL',
      '2025-06-11 20:00:00+00', '2025-06-11 21:00:00+00',
      '{"vehicleType": "VESSEL", "actionNumberOfControls": 1, "infractions": [{"natinf": [1234], "infractionType": "WITH_REPORT"}]}'),
 
-    -- 4.4 : biens culturels maritimes, police (thème 104)
+    -- 4.4 : biens culturels maritimes, police (thème 999104)
     ('99999905-0000-0000-0000-000000000004', 999001, 'CONTROL',
      '2025-06-12 07:00:00+00', '2025-06-12 07:30:00+00',
      '{"vehicleType": "VESSEL"}'),
 
-    -- 4.4 : biens culturels maritimes, opération scientifique (thème 165)
+    -- 4.4 : biens culturels maritimes, opération scientifique (thème 999165)
     ('99999905-0000-0000-0000-000000000005', 999001, 'SURVEILLANCE',
      '2025-06-12 08:00:00+00', '2025-06-12 09:00:00+00',
      '{}')
@@ -62,8 +62,8 @@ INSERT INTO public.env_actions (
 INSERT INTO public.themes_env_actions (
     env_actions_id, themes_id
 ) VALUES
-    ('99999905-0000-0000-0000-000000000001', 103),
-    ('99999905-0000-0000-0000-000000000003', 19),
-    ('99999905-0000-0000-0000-000000000004', 104),
-    ('99999905-0000-0000-0000-000000000005', 165)
+    ('99999905-0000-0000-0000-000000000001', 999103),
+    ('99999905-0000-0000-0000-000000000003', 99919),
+    ('99999905-0000-0000-0000-000000000004', 999104),
+    ('99999905-0000-0000-0000-000000000005', 999165)
 ;

--- a/forklift/tests/test_data/monitorfish/remote_database/V777.13__dummy_mission_actions_aem_test.sql
+++ b/forklift/tests/test_data/monitorfish/remote_database/V777.13__dummy_mission_actions_aem_test.sql
@@ -9,11 +9,11 @@
 
 INSERT INTO public.mission_actions (
     id, mission_id, action_type, action_datetime_utc, action_end_datetime_utc,
-    completion, infractions, seizure_and_diversion, species_quantity_seized
+    completion, infractions, seizure_and_diversion, species_quantity_seized, flag_state, user_trigram
 ) VALUES (
     999001, 999001, 'SEA_CONTROL',
     '2025-06-12 14:00:00+00', '2025-06-12 15:00:00+00',
     'COMPLETED',
     '[{"natinf": 27692, "infractionType": "WITH_RECORD"}]'::jsonb,
-    true, 42.5
+    true, 42.5, 'FRA', 'ABC'
 );

--- a/forklift/tests/test_data/monitorfish/remote_database/V777.14__dummy_beacon_malfunction_comments.sql
+++ b/forklift/tests/test_data/monitorfish/remote_database/V777.14__dummy_beacon_malfunction_comments.sql
@@ -1,0 +1,5 @@
+INSERT INTO beacon_malfunction_comments (
+    beacon_malfunction_id,                                                         comment, user_type,             date_time_utc) VALUES
+(                       1,                                       'APPEL VERS NAVIRE - NRP',     'SIP',	'2022-11-02 10:51:35+00'),
+(                       2,           'Emissions VMS stoppé - navire en attente d activité',     'SIP',	'2022-11-14 07:34:46+00'),
+(                       3, 'annulé commentaire précedent concernant l''arret des emission',     'SIP',	'2022-11-14 07:35:59+00');

--- a/infra/testing/docker-compose-test-data.yml
+++ b/infra/testing/docker-compose-test-data.yml
@@ -90,6 +90,18 @@ services:
       rapportnav-db:
         condition: service_healthy
 
+  migration-sentinel:
+    image: alpine
+    container_name: migration_sentinel
+    command: ["echo", "OK"]
+    depends_on:
+      monitorfish-flyway:
+        condition: service_completed_successfully
+      monitorenv-flyway:
+        condition: service_completed_successfully
+      rapportnav-flyway:
+        condition: service_completed_successfully
+
 volumes:
   monitorfish-db-data:
     driver: local


### PR DESCRIPTION
Resolve #234 + résolution des test data qui ne passaient pas et ajout d'un service "sentinel" qui fail si les containers flyway sortent en erreur, de sorte à détecter les migrations de test data qui ne passent pas.